### PR TITLE
Add support for uninstalling outdated Python versions

### DIFF
--- a/crates/uv-cli/src/lib.rs
+++ b/crates/uv-cli/src/lib.rs
@@ -5554,12 +5554,16 @@ pub struct PythonUninstallArgs {
     /// The Python version(s) to uninstall.
     ///
     /// See `uv help python` to view supported request formats.
-    #[arg(required = true)]
+    #[arg(required_unless_present_any = ["all", "outdated"], conflicts_with = "outdated")]
     pub targets: Vec<String>,
 
     /// Uninstall all managed Python versions.
-    #[arg(long, conflicts_with("targets"))]
+    #[arg(long, conflicts_with_all = ["targets", "outdated"])]
     pub all: bool,
+
+    /// Uninstall outdated managed Python versions.
+    #[arg(long, conflicts_with_all = ["targets", "all"])]
+    pub outdated: bool,
 }
 
 #[derive(Args)]

--- a/crates/uv/src/commands/python/uninstall.rs
+++ b/crates/uv/src/commands/python/uninstall.rs
@@ -29,6 +29,7 @@ pub(crate) async fn uninstall(
     install_dir: Option<PathBuf>,
     targets: Vec<String>,
     all: bool,
+    outdated: bool,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
@@ -37,7 +38,7 @@ pub(crate) async fn uninstall(
     let _lock = installations.lock().await?;
 
     // Perform the uninstallation.
-    do_uninstall(&installations, targets, all, printer, preview).await?;
+    do_uninstall(&installations, targets, all, outdated, printer, preview).await?;
 
     // Clean up any empty directories.
     if uv_fs::directories(installations.root())?.all(|path| uv_fs::is_temporary(&path)) {
@@ -65,79 +66,110 @@ async fn do_uninstall(
     installations: &ManagedPythonInstallations,
     targets: Vec<String>,
     all: bool,
+    outdated: bool,
     printer: Printer,
     preview: Preview,
 ) -> Result<ExitStatus> {
     let start = std::time::Instant::now();
 
-    let requests = if all {
-        vec![PythonRequest::Default]
-    } else {
-        let targets = targets.into_iter().collect::<BTreeSet<_>>();
-        targets
-            .iter()
-            .map(|target| PythonRequest::parse(target.as_str()))
-            .collect::<Vec<_>>()
-    };
-
-    let download_requests = requests
-        .iter()
-        .map(|request| {
-            PythonDownloadRequest::from_request(request).ok_or_else(|| {
-                anyhow::anyhow!("Cannot uninstall managed Python for request: {request}")
-            })
-        })
-        // Always include pre-releases in uninstalls
-        .map(|result| result.map(|request| request.with_prereleases(true)))
-        .collect::<Result<Vec<_>>>()?;
     let installed_installations: Vec<_> = installations.find_all()?.collect();
     let mut matching_installations = BTreeSet::default();
-    for (request, download_request) in requests.iter().zip(download_requests) {
-        if matches!(requests.as_slice(), [PythonRequest::Default]) {
-            writeln!(printer.stderr(), "Searching for Python installations")?;
-        } else {
-            writeln!(
-                printer.stderr(),
-                "Searching for Python versions matching: {}",
-                request.cyan()
-            )?;
+
+    if outdated {
+        writeln!(printer.stderr(), "Searching for Python installations")?;
+
+        if installed_installations.is_empty() {
+            writeln!(printer.stderr(), "No Python installations found")?;
+            return Ok(ExitStatus::Failure);
         }
-        let mut found = false;
-        for installation in installed_installations
-            .iter()
-            .filter(|installation| download_request.satisfied_by_key(installation.key()))
-        {
-            found = true;
-            matching_installations.insert(installation.clone());
-        }
-        if !found {
-            // Clear any remnants in the registry
-            #[cfg(windows)]
+
+        let latest_installations =
+            PythonInstallationMinorVersionKey::highest_installations_by_minor_version_key(
+                installed_installations.iter(),
+            );
+
+        for installation in &installed_installations {
+            if latest_installations
+                .get(installation.minor_version_key())
+                .is_some_and(|latest_installation| latest_installation.key() != installation.key())
             {
-                uv_python::windows_registry::remove_orphan_registry_entries(
-                    &installed_installations,
-                );
+                matching_installations.insert(installation.clone());
             }
+        }
 
+        if matching_installations.is_empty() {
+            writeln!(printer.stderr(), "No outdated Python versions found")?;
+            return Ok(ExitStatus::Success);
+        }
+    } else {
+        let requests = if all {
+            vec![PythonRequest::Default]
+        } else {
+            let targets = targets.into_iter().collect::<BTreeSet<_>>();
+            targets
+                .iter()
+                .map(|target| PythonRequest::parse(target.as_str()))
+                .collect::<Vec<_>>()
+        };
+
+        let download_requests = requests
+            .iter()
+            .map(|request| {
+                PythonDownloadRequest::from_request(request).ok_or_else(|| {
+                    anyhow::anyhow!("Cannot uninstall managed Python for request: {request}")
+                })
+            })
+            // Always include pre-releases in uninstalls
+            .map(|result| result.map(|request| request.with_prereleases(true)))
+            .collect::<Result<Vec<_>>>()?;
+
+        for (request, download_request) in requests.iter().zip(download_requests) {
             if matches!(requests.as_slice(), [PythonRequest::Default]) {
-                writeln!(printer.stderr(), "No Python installations found")?;
-                return Ok(ExitStatus::Failure);
+                writeln!(printer.stderr(), "Searching for Python installations")?;
+            } else {
+                writeln!(
+                    printer.stderr(),
+                    "Searching for Python versions matching: {}",
+                    request.cyan()
+                )?;
             }
+            let mut found = false;
+            for installation in installed_installations
+                .iter()
+                .filter(|installation| download_request.satisfied_by_key(installation.key()))
+            {
+                found = true;
+                matching_installations.insert(installation.clone());
+            }
+            if !found {
+                // Clear any remnants in the registry
+                #[cfg(windows)]
+                {
+                    uv_python::windows_registry::remove_orphan_registry_entries(
+                        &installed_installations,
+                    );
+                }
 
+                if matches!(requests.as_slice(), [PythonRequest::Default]) {
+                    writeln!(printer.stderr(), "No Python installations found")?;
+                    return Ok(ExitStatus::Failure);
+                }
+
+                writeln!(
+                    printer.stderr(),
+                    "No existing installations found for: {}",
+                    request.cyan()
+                )?;
+            }
+        }
+
+        if matching_installations.is_empty() {
             writeln!(
                 printer.stderr(),
-                "No existing installations found for: {}",
-                request.cyan()
+                "No Python installations found matching the requests"
             )?;
+            return Ok(ExitStatus::Failure);
         }
-    }
-
-    if matching_installations.is_empty() {
-        writeln!(
-            printer.stderr(),
-            "No Python installations found matching the requests"
-        )?;
-        return Ok(ExitStatus::Failure);
     }
 
     // Remove registry entries first, so we don't have dangling entries between the file removal

--- a/crates/uv/src/lib.rs
+++ b/crates/uv/src/lib.rs
@@ -1551,6 +1551,7 @@ async fn run(mut cli: Cli) -> Result<ExitStatus> {
                 args.install_dir,
                 args.targets,
                 args.all,
+                args.outdated,
                 printer,
                 globals.preview,
             )

--- a/crates/uv/src/settings.rs
+++ b/crates/uv/src/settings.rs
@@ -1095,6 +1095,7 @@ pub(crate) struct PythonUninstallSettings {
     pub(crate) install_dir: Option<PathBuf>,
     pub(crate) targets: Vec<String>,
     pub(crate) all: bool,
+    pub(crate) outdated: bool,
 }
 
 impl PythonUninstallSettings {
@@ -1108,12 +1109,14 @@ impl PythonUninstallSettings {
             install_dir,
             targets,
             all,
+            outdated,
         } = args;
 
         Self {
             install_dir,
             targets,
             all,
+            outdated,
         }
     }
 }

--- a/crates/uv/tests/it/python_install.rs
+++ b/crates/uv/tests/it/python_install.rs
@@ -1,7 +1,7 @@
 #[cfg(windows)]
 use std::path::PathBuf;
 
-use std::{env, path::Path, process::Command};
+use std::{env, fs, path::Path, process::Command};
 
 use crate::common::{TestContext, uv_snapshot};
 use assert_cmd::assert::OutputAssertExt;
@@ -119,7 +119,7 @@ fn python_install() {
     error: the following required arguments were not provided:
       <TARGETS>...
 
-    Usage: uv python uninstall --install-dir <INSTALL_DIR> <TARGETS>...
+    Usage: uv python uninstall --install-dir <INSTALL_DIR> --no-progress <TARGETS>...
 
     For more information, try '--help'.
     "###);
@@ -226,6 +226,98 @@ fn python_reinstall_patch() {
     Installed Python 3.12.11 in [TIME]
      + cpython-3.12.11-[PLATFORM] (python3.12)
     ");
+}
+
+#[test]
+fn python_uninstall_outdated() {
+    let context: TestContext = TestContext::new_with_versions(&[])
+        .with_filtered_python_keys()
+        .with_filtered_exe_suffix()
+        .with_managed_python_dirs()
+        .with_python_download_cache();
+
+    uv_snapshot!(
+        context.filters(),
+        context
+            .python_install()
+            .arg("3.12.5")
+            .arg("3.12.6")
+            .arg("3.12.7"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Installed 3 versions in [TIME]
+     + cpython-3.12.5-[PLATFORM]
+     + cpython-3.12.6-[PLATFORM]
+     + cpython-3.12.7-[PLATFORM] (python3.12)
+    "
+    );
+
+    uv_snapshot!(
+        context.filters(),
+        context.python_uninstall().arg("--outdated"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Searching for Python installations
+    Uninstalled 2 versions in [TIME]
+     - cpython-3.12.5-[PLATFORM]
+     - cpython-3.12.6-[PLATFORM]
+    "
+    );
+
+    let managed_dir = context.temp_dir.child("managed");
+    let installs: Vec<String> = fs::read_dir(managed_dir.path())
+        .unwrap()
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            entry
+                .file_type()
+                .ok()
+                .filter(|file_type| file_type.is_dir())
+                .and_then(|_| entry.file_name().into_string().ok())
+        })
+        .filter(|name| name.starts_with("cpython-"))
+        .collect();
+
+    assert!(
+        installs
+            .iter()
+            .any(|name| name.starts_with("cpython-3.12.7-")),
+        "expected Python 3.12.7 to remain installed, found {installs:?}"
+    );
+    assert!(
+        !installs
+            .iter()
+            .any(|name| name.starts_with("cpython-3.12.5-")),
+        "expected outdated Python versions to be removed, found {installs:?}"
+    );
+    assert!(
+        !installs
+            .iter()
+            .any(|name| name.starts_with("cpython-3.12.6-")),
+        "expected outdated Python versions to be removed, found {installs:?}"
+    );
+
+    uv_snapshot!(
+        context.filters(),
+        context.python_uninstall().arg("--outdated"),
+        @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+
+    ----- stderr -----
+    Searching for Python installations
+    No outdated Python versions found
+    "
+    );
 }
 
 #[test]
@@ -750,7 +842,7 @@ fn python_install_preview() {
     error: the following required arguments were not provided:
       <TARGETS>...
 
-    Usage: uv python uninstall --install-dir <INSTALL_DIR> <TARGETS>...
+    Usage: uv python uninstall --install-dir <INSTALL_DIR> --no-progress <TARGETS>...
 
     For more information, try '--help'.
     "###);
@@ -2263,7 +2355,7 @@ fn python_install_default_from_env() {
     error: the following required arguments were not provided:
       <TARGETS>...
 
-    Usage: uv python uninstall --install-dir <INSTALL_DIR> <TARGETS>...
+    Usage: uv python uninstall --install-dir <INSTALL_DIR> --no-progress <TARGETS>...
 
     For more information, try '--help'.
     "###);
@@ -2291,7 +2383,7 @@ fn python_install_default_from_env() {
     error: the following required arguments were not provided:
       <TARGETS>...
 
-    Usage: uv python uninstall --install-dir <INSTALL_DIR> <TARGETS>...
+    Usage: uv python uninstall --install-dir <INSTALL_DIR> --no-progress <TARGETS>...
 
     For more information, try '--help'.
     "###);
@@ -2305,7 +2397,7 @@ fn python_install_default_from_env() {
     ----- stderr -----
     error: the argument '--all' cannot be used with '<TARGETS>...'
 
-    Usage: uv python uninstall --all --install-dir <INSTALL_DIR> <TARGETS>...
+    Usage: uv python uninstall --all --install-dir <INSTALL_DIR> --no-progress <TARGETS>...
 
     For more information, try '--help'.
     "###);
@@ -2624,7 +2716,7 @@ fn python_install_no_cache() {
     error: the following required arguments were not provided:
       <TARGETS>...
 
-    Usage: uv python uninstall --install-dir <INSTALL_DIR> <TARGETS>...
+    Usage: uv python uninstall --install-dir <INSTALL_DIR> --no-progress <TARGETS>...
 
     For more information, try '--help'.
     "###);

--- a/docs/getting-started/features.md
+++ b/docs/getting-started/features.md
@@ -13,7 +13,7 @@ Installing and managing Python itself.
 - `uv python list`: View available Python versions.
 - `uv python find`: Find an installed Python version.
 - `uv python pin`: Pin the current project to use a specific Python version.
-- `uv python uninstall`: Uninstall a Python version.
+- `uv python uninstall`: Uninstall Python versions, or prune outdated installations with `--outdated`.
 
 See the [guide on installing Python](../guides/install-python.md) to get started.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -3838,7 +3838,7 @@ Uninstall Python versions
 <h3 class="cli-reference">Usage</h3>
 
 ```
-uv python uninstall [OPTIONS] <TARGETS>...
+uv python uninstall [OPTIONS] [TARGETS]...
 ```
 
 <h3 class="cli-reference">Arguments</h3>
@@ -3850,6 +3850,7 @@ uv python uninstall [OPTIONS] <TARGETS>...
 <h3 class="cli-reference">Options</h3>
 
 <dl class="cli-reference"><dt id="uv-python-uninstall--all"><a href="#uv-python-uninstall--all"><code>--all</code></a></dt><dd><p>Uninstall all managed Python versions</p>
+</dd><dt id="uv-python-uninstall--outdated"><a href="#uv-python-uninstall--outdated"><code>--outdated</code></a></dt><dd><p>Uninstall outdated managed Python versions</p>
 </dd><dt id="uv-python-uninstall--allow-insecure-host"><a href="#uv-python-uninstall--allow-insecure-host"><code>--allow-insecure-host</code></a>, <code>--trusted-host</code> <i>allow-insecure-host</i></dt><dd><p>Allow insecure connections to a host.</p>
 <p>Can be provided multiple times.</p>
 <p>Expects to receive either a hostname (e.g., <code>localhost</code>), a host-port pair (e.g., <code>localhost:8080</code>), or a URL (e.g., <code>https://localhost</code>).</p>


### PR DESCRIPTION
## Summary
- add a `--outdated` flag to `uv python uninstall` and plumb it through the CLI settings
- update the uninstall command to prune older installations and gracefully report when nothing is outdated
- document the new flag and cover it with an integration test

## Testing
- cargo test -p uv --test it python_uninstall_outdated -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68d41cbb37dc832baa35fcae22571d44